### PR TITLE
[Alerts] The alert details pane doesn't close after filtering

### DIFF
--- a/src/components/Alerts/AlertsView.js
+++ b/src/components/Alerts/AlertsView.js
@@ -95,7 +95,7 @@ const AlertsView = ({
               {isAlertsPage && (
                 <ActionBar
                   autoRefreshIsStopped={true}
-                  closeParamName={ALERTS_PAGE_PATH}
+                  closeParamName={isCrossProjects ? MONITOR_ALERTS_PAGE : ALERTS_PAGE_PATH}
                   filterMenuName={ALERTS_FILTERS}
                   filters={filters}
                   filtersConfig={isAlertsPage ? alertsFiltersConfig : {}}


### PR DESCRIPTION
- **The alert details pane doesn't close after filtering in the monitor page
  **Jira**: [ML-9376](https://iguazio.atlassian.net/browse/ML-9376)
