### PR TITLE
Fix [Projects Alerts] Severity tab text should use ellipsis on small screens

### DIFF
--- a/src/utils/createAlertsContent.js
+++ b/src/utils/createAlertsContent.js
@@ -123,7 +123,7 @@ const getSeverityData = severity => {
         value: (
           <div className="alert-row__details-alert-icon-cell">
             <Low />
-            <span>{upperFirst(SEVERITY_LOW)}</span>
+            <span className={'data-ellipsis'}>{upperFirst(SEVERITY_LOW)}</span>
           </div>
         ),
         tooltip: upperFirst(SEVERITY_LOW)
@@ -133,7 +133,7 @@ const getSeverityData = severity => {
         value: (
           <div className="alert-row__details-alert-icon-cell">
             <Normal />
-            <span>{upperFirst(SEVERITY_MEDIUM)}</span>
+            <span className={'data-ellipsis'}>{upperFirst(SEVERITY_MEDIUM)}</span>
           </div>
         ),
         tooltip: upperFirst(SEVERITY_MEDIUM)
@@ -143,7 +143,7 @@ const getSeverityData = severity => {
         value: (
           <div className="alert-row__details-alert-icon-cell">
             <High />
-            <span>{upperFirst(SEVERITY_HIGH)}</span>
+            <span className={'data-ellipsis'}>{upperFirst(SEVERITY_HIGH)}</span>
           </div>
         ),
         tooltip: upperFirst(SEVERITY_HIGH)
@@ -153,7 +153,7 @@ const getSeverityData = severity => {
         value: (
           <div className="alert-row__details-alert-icon-cell">
             <Critical />
-            <span>{upperFirst(SEVERITY_CRITICAL)}</span>
+            <span className={'data-ellipsis'}>{upperFirst(SEVERITY_CRITICAL)}</span>
           </div>
         ),
         tooltip: upperFirst(SEVERITY_CRITICAL)


### PR DESCRIPTION
**Jira**: [ML-9496](https://iguazio.atlassian.net/browse/ML-9496)

before:
<img width="93" alt="Actual" src="https://github.com/user-attachments/assets/ac0de88f-e649-4130-9bbb-9670d28c004c" />

after:
<img width="109" alt="Expected" src="https://github.com/user-attachments/assets/0783015e-6b5e-41f7-8494-cbf61d80a922" />

<img width="191" alt="Screenshot 2025-03-16 at 12 18 04" src="https://github.com/user-attachments/assets/23a2cb16-4150-4710-8e61-ccb74b50b8a4" />




